### PR TITLE
Update config-file dependency to newer version to support Node v5+

### DIFF
--- a/index.js
+++ b/index.js
@@ -133,7 +133,7 @@ var wink = {
 	init: function(auth_data, callback) {
 		if ( auth_data.conf !== undefined ) {
 			// get data from config
-			auth_data = config.load(auth_data.conf);
+			auth_data = config.parse(auth_data.conf);
 		}
 
 		if ( process.env.WINK_HOST ) {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "async": "*",
-    "config-file": "~0.1.8",
+    "config-file": "~0.3.0",
     "debug": ""
   },
   "devDependencies": {


### PR DESCRIPTION
I believe the reason for the issue in Node v5+ is because wink-js is specifying config-file as a dependency, version 0.1.8. Later versions of config-file (3.0) apparently changed the function calls, so you could no longer use .load (which is invoked in wink-js's index.js), but had to use .parse or another option, depending on what you needed to do.

Regardless, the underlying issue is that in config-file 0.1.8 it makes a call on line 17 to path.dirname (https://github.com/jonschlinkert/config-file/blob/2743b333bf8b24bcd148e0276ab31b1ff67f46d9/index.js), and in earlier versions of Node (like 4.7.0) there was no type check on the call to dirname (see https://nodejs.org/docs/latest-v4.x/doc/api/path.html#path_path_dirname_p), so it wouldn't throw an error if this was null, however in later versions of Node, you'll find there is a type check: https://nodejs.org/api/path.html#path_path_dirname_path, "A TypeError is thrown if path is not a string.".

I'm proposing to call config-file v3.0x and updated config.load (deprecated) to config.parse for the auth payload.  I've tested this with more recent versions of Node and it works now without throwing the type exception seen in apps that depend on wink-js (eg homebridge-wink: https://github.com/KraigM/homebridge-wink/issues/59).  This concern is also mentioned here: https://github.com/winfinit/wink-js/issues/9.