### PR TITLE
Updating Wink base URI to wink.com domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,14 +87,14 @@ response:
         "access_token": "xxx",
         "refresh_token": "xxx",
         "token_type": "bearer",
-        "token_endpoint": "https://winkapi.quirky.com/oauth2/token"
+        "token_endpoint": "https://api.wink.com/oauth2/token"
     },
     "errors": [],
     "pagination": {},
     "access_token": "xxx",
     "refresh_token": "xxx",
     "token_type": "bearer",
-    "token_endpoint": "https://winkapi.quirky.com/oauth2/token"
+    "token_endpoint": "https://api.wink.com/oauth2/token"
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -141,7 +141,7 @@ var wink = {
 		} else if ( auth_data.hostname ) {
 			winkUri = auth_data.hostname;
 		} else {
-			winkUri = "winkapi.quirky.com";
+			winkUri = "api.wink.com";
 		}
 
 		if ( process.env.WINK_PORT ) {

--- a/mock-server/wink_api.md
+++ b/mock-server/wink_api.md
@@ -1,6 +1,6 @@
 FORMAT: 1A
 
-HOST: https://winkapi.quirky.com
+HOST: https://api.wink.com
 
 # Wink API
 The Wink API connects Wink devices to users, apps, each other, and the wider web.
@@ -128,7 +128,7 @@ A user has the following specific attributes:
               "access_token": "example_access_token_like_135fhn80w35hynainrsg0q824hyn",
               "refresh_token": "...",
               "token_type": "bearer",
-              "token_endpoint": "https://winkapi.quirky.com/oauth2/token"
+              "token_endpoint": "https://api.wink.com/oauth2/token"
             },
             "locale": "en_us",
             "units": {},


### PR DESCRIPTION
Switching to use the `api.wink.com` base URI instead of `winkapi.quirky.com`.

Thanks!
~ Gabe